### PR TITLE
Better state loading performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # This work is licensed under the terms of the GNU GPL, version 2. See the    #
 # COPYING file in the top-level directory.                                    #
 ###############################################################################
-CXXFLAGS ?= -g -Wall -Idistorm/ -std=c++11
+CXXFLAGS ?= -g -Wall -Idistorm/ -std=c++11 -march=native
 QSIM_PREFIX ?= /usr/local
 LDFLAGS = -L./
 LDLIBS = -lqsim -ldl -lrt
@@ -17,7 +17,7 @@ all: libqsim.so qsim-fastforwarder
 
 debug: CXXFLAGS += -O0
 debug: BUILD_DIR = .dbg_build
-release: CXXFLAGS += -O2
+release: CXXFLAGS += -O3
 release: BUILD_DIR = .opt_build
 
 statesaver.o: statesaver.cpp statesaver.h qsim.h

--- a/fastforwarder.cpp
+++ b/fastforwarder.cpp
@@ -124,21 +124,9 @@ int main(int argc, char** argv) {
   std::cout << "Tracing 1M instructions.\n";
 #endif
 
-#ifdef LOAD
-  int runfor = 10000;
-#else
-  int runfor = 9999;
-#endif
-  for (unsigned i = 0; i < 1; ++i) {
-    for (unsigned j = 0; j < 100; ++j) {
-      for (int k = 0; k < cpus; ++k) {
-        osd.run(runfor);
-      }
-#ifndef LOAD
-      runfor = 10000;
-#endif
-    }
-    osd.timer_interrupt();
+  int runfor = 10000, ran = runfor;
+  while (ran == runfor) {
+    ran = osd.run(runfor);
   }
 
   std::cout << "Finished.\n";

--- a/initrd/init
+++ b/initrd/init
@@ -19,6 +19,9 @@ cd data
 
 /sbin/mark_app
 
+echo Restoring state
+echo Copying benchmark binary...
+
 /sbin/qsim_in | tar -x
 if [ $? != 0 ]; then
   echo Untar input failed. Are you providing a .tar archive? | /sbin/qsim_out
@@ -28,8 +31,9 @@ if [ ! -e runme.sh ]; then
   echo \"runme.sh\" not found. Input .tar must contain this. | /sbin/qsim_out
 fi
 
+echo Executing benchmark
 /sbin/chmod +x ./runme.sh
-/sbin/ash ./runme.sh 2>&1 | /sbin/qsim_out
+/sbin/ash ./runme.sh
 
 echo --- program exit, will shutdown shortly... ---
 # Spin forever.

--- a/linux/linux-4.1.17.qsim.config
+++ b/linux/linux-4.1.17.qsim.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.1.15 Kernel Configuration
+# Linux/x86 4.1.17 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y
@@ -279,7 +279,7 @@ CONFIG_HPET_TIMER=y
 CONFIG_SWIOTLB=y
 CONFIG_IOMMU_HELPER=y
 # CONFIG_MAXSMP is not set
-CONFIG_NR_CPUS=32
+CONFIG_NR_CPUS=64
 # CONFIG_SCHED_SMT is not set
 CONFIG_SCHED_MC=y
 CONFIG_PREEMPT_NONE=y

--- a/qsim-load.cpp
+++ b/qsim-load.cpp
@@ -33,10 +33,10 @@ public:
     
     // The main loop: run until 'finished' is true.                            
     while (!finished) {
-      for (int i = 0; i < osd.get_n(); i++)
-        osd.run(i, 100);
-      if (!finished) osd.timer_interrupt();
+      osd.run(100 * osd.get_n());
     }
+
+    osd.run(finished_core, 1);
 
     // Unset the callbacks.
     osd.unset_magic_cb(magic_handle);
@@ -47,9 +47,11 @@ private:
   OSDomain &osd;  
   ifstream &infile;
   bool finished;
+  int finished_core;
 
-  int app_start_cb(int) {
+  int app_start_cb(int c) {
     finished = true;
+    finished_core = c;
     return 1;
   }
 


### PR DESCRIPTION
- Fix a nasty case of bad performance when loading state files for large cores. This is done by increasing the run granularity according to the number of cores. 
- Gracefully return after saving state instead of exiting. This helps us in deleting the temporary qsim library file which otherwise would clog up space.
