### PR TITLE
update the qsim script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ initrd/initrd.cpio.arm64
 include/
 .dbg_build
 .opt_build
+tools
+images

--- a/mkstate.sh
+++ b/mkstate.sh
@@ -23,12 +23,15 @@ fi
 
 # Truncate our log file
 echo > mkstate.log
+echo > mkstate.a64.log
 
 for i in `seq $LOG2MINCPUS $LOG2MAXCPUS`; do
   n=`echo 2 $i ^ p | dc`
   echo "-- running qsim-fastforwarder for $n core(s) --"
   $FF linux/bzImage $n $RAMSIZE state.$n 2>&1 >> mkstate.log
-
+  if [ "$n" -le 8 ]; then
+    $FF linux/Image $n $RAMSIZE state.$n.a64 a64 2>&1 >> mkstate.a64.log
+  fi
 #  examples/io-test \
 #    $n TRACE state.$n ../benchmarks/splash2-tar/fft.tar > state.$n.testout &
 done

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,28 @@ normal=$(tput sgr0)
 
 ARCH=$1
 
+# setup the aarch64 toolchain
+aarch64_tool=$PWD/tools/gcc-linaro-5.1-2015.08-x86_64_aarch64-linux-gnu
+
+if command -v aarch64-linux-gnu-gcc >/dev/null 2>&1 ; then
+    echo "AARCH64 toolchain is already installed!"
+else
+    echo "\nAARCH64 toolchain is not set, download from linaro website..."
+    echo "Press any key to continue..."
+    read inp
+    mkdir -p tools
+    cd tools 
+    wget -c "https://releases.linaro.org/components/toolchain/binaries/latest-5.1/aarch64-linux-gnu/gcc-linaro-5.1-2015.08-x86_64_aarch64-linux-gnu.tar.xz" -O aarch64_toolchain.tar.xz
+    echo "\nUncompressing the toolchain..."
+    tar -xf aarch64_toolchain.tar.xz
+    export PATH="$PATH:$aarch64_tool/bin"
+    echo "\n\nAdd the following lines to your bashrc:\n"
+    echo "${bold}export PATH=\$PATH:\$QSIM_PREFIX/gcc-linaro-5.1-2015.08-x86_64_aarch64-linux-gnu/bin${normal}"
+    echo "Press any key to continue..."
+    read inp
+    cd ..
+fi
+
 # set the QSIM environment variable
 echo "Setting QSIM environment variable..."
 export QSIM_PREFIX=`pwd`
@@ -20,7 +42,6 @@ echo "\n\nAdd the following lines to your bashrc:\n"
 echo "${bold}export QSIM_PREFIX=$QSIM_PREFIX${bold}"
 echo "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$QSIM_PREFIX/lib${normal}\n"
 echo "Press any key to continue..."
-
 read inp
 
 echo "\n\nDown QEMU OS images? This will take a while. (Y/n):"
@@ -30,12 +51,14 @@ read inp
 echo "Installing dependencies..."
 echo "sudo apt-get -y build-dep qemu"
 sudo apt-get -y build-dep qemu
-sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+#sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 if [ "$inp" = "y" -o "$inp" = "Y" ]; then
   cd ..
   # get qemu images
   echo "\nDownloading arm QEMU images..."
+  mkdir -p images
+  cd images
   wget -c https://www.dropbox.com/s/2jplu61410tfime/arm64_images.tar.xz?dl=0 -O arm64_images.tar.xz
   wget -c https://www.dropbox.com/s/4ut7e4d5ygty020/x86_64_images.tar.xz?dl=0 -O x86_64_images.tar.xz
 


### PR DESCRIPTION
The new scripts update the following:

1, the aarch64 toolchain now directly downloads from the linaro website to avoid distro-dependency
2, qemu images now relocates into qemu/images directory
3, arm64 state images are generated using the mkstate.sh
