### PR TITLE
close temp file to eliminate "Error while mapping shared library sect…

### DIFF
--- a/mgzd.h
+++ b/mgzd.h
@@ -64,6 +64,7 @@ namespace Mgzd {
         exit(1);
       }
     }
+    fclose(fp);
 
     // Make temporary copy of libfile, so opening multiple copies of the same
     // file results in independent copies of global variables.


### PR DESCRIPTION
…ions: `/tmp/qsim_XXXXXX': not in executable format: File truncated" error message seen on Fedora 22 (possibly on other systems as well) and more importantly allow debugging of QEMU code. Unable to debug QEMU code without the fclose().
