### PR TITLE
proposed qsim update for the rebase of qemu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,11 @@ initrd/test_inst
 initrd/test_mem
 initrd/initrd.cpio.x86
 initrd/initrd.cpio.arm64
+initrd/busybox-1.26.2
 include/
 .dbg_build
 .opt_build
 tools
 images
 build
+mkstate.a64.log

--- a/build-qemu.sh
+++ b/build-qemu.sh
@@ -20,7 +20,7 @@ mkdir -p $QSIM_PREFIX/lib/
 if [ ! -d "$build_dir" ]; then
   mkdir -p $build_dir
   cd $build_dir
-  QEMU_CFLAGS="-I${QSIM_PREFIX} -g -fPIC -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wno-deprecated-declarations -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wtype-limits -fstack-protector-all -Wno-uninitialized" ../qemu/configure --extra-ldflags=-shared --target-list=aarch64-softmmu,x86_64-softmmu --disable-pie --disable-brlapi --disable-rdma --disable-rbd --disable-tcmalloc --disable-xen --disable-gtk --disable-glusterfs --disable-xfsctl --disable-uuid $debug_flags
+  QEMU_CFLAGS="-I${QSIM_PREFIX} -g -fPIC -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wno-deprecated-declarations -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wtype-limits -fstack-protector-all -Wno-uninitialized" ../qemu/configure --extra-ldflags=-shared --target-list=aarch64-softmmu,x86_64-softmmu --disable-pie --disable-brlapi --disable-rdma --disable-rbd --disable-tcmalloc --disable-xen --disable-gtk --disable-glusterfs --disable-xfsctl --disable-uuid $debug_flags --datadir=$QSIM_PREFIX/qemu/pc-bios --with-confsuffix=/
 else
   cd $build_dir
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -68,6 +68,11 @@ echo -e "Building distorm disassembler..."
 cd ../distorm/distorm64/build/linux
 make clib 2> /dev/null
 cd $QSIM_PREFIX
+echo -e "Get qemu submodules..."
+cd qemu
+git submodule update --init pixman
+git submodule update --init dtc
+cd $QSIM_PREFIX
 
 # build linux kernel and initrd
 echo -e "Building Linux kernel..."

--- a/setup_sudo.sh
+++ b/setup_sudo.sh
@@ -74,12 +74,17 @@ fi
 
 # update submodules
 git submodule update --init
-echo "Building capstone disassembler..."
+echo -e "Building capstone disassembler..."
 cd capstone
 make -j4
-echo "Building distorm disassembler..."
+echo -e "Building distorm disassembler..."
 cd ../distorm/distorm64/build/linux
 make clib 2> /dev/null
+cd $QSIM_PREFIX
+echo -e "Get qemu submodules..."
+cd qemu
+git submodule update --init pixman
+git submodule update --init dtc
 cd $QSIM_PREFIX
 
 # build linux kernel and initrd


### PR DESCRIPTION
QEMU-QSIM Version from 2.5 to 2.6 stable.

.gitignore:
	add initrd/busybox-1.26.2;
	add mkstate.a64.log;

setup.sh / setup_sudo.sh:
	FIX before qemu can be builded we must
        update the qemu submodules;

build-qemu.sh:
	FIX the qemu bios files should be set
	to the source code;