### PR TITLE
examples/x86: fix return value in simple.cpp

### DIFF
--- a/examples/x86/simple.cpp
+++ b/examples/x86/simple.cpp
@@ -41,7 +41,7 @@ public:
       osd.set_reg_cb(this, &TraceWriter::reg_cb);
       osd.set_app_end_cb(this, &TraceWriter::app_end_cb);
 
-      return 1;
+      return 0;
     }
 
     return 0;


### PR DESCRIPTION
app_start_cb was returning 1 instead of 0 which was causing
the simulation to end abruptly